### PR TITLE
fix: update app resource APIs to accept `void*`

### DIFF
--- a/seekcamera/_clib.py
+++ b/seekcamera/_clib.py
@@ -269,7 +269,7 @@ def configure_dll():
     _cdll.seekcamera_load_app_resources.argtypes = [
         ctypes.c_void_p,
         ctypes.c_int32,
-        ctypes.POINTER(ctypes.c_byte),
+        ctypes.POINTER(ctypes.c_void_p),
         _SEEKCAMERA_MEMORY_ACCESS_CALLBACK_T,
         ctypes.py_object,
     ]
@@ -279,7 +279,7 @@ def configure_dll():
     _cdll.seekcamera_store_app_resources.argtypes = [
         ctypes.c_void_p,
         ctypes.c_int32,
-        ctypes.POINTER(ctypes.c_byte),
+        ctypes.POINTER(ctypes.c_void_p),
         ctypes.c_size_t,
         _SEEKCAMERA_MEMORY_ACCESS_CALLBACK_T,
         ctypes.py_object,
@@ -748,10 +748,12 @@ def cseekcamera_delete_flat_scene_correction(camera, fsc_id, callback, user_data
 
 def cseekcamera_load_app_resources(camera, region, data_size, callback, user_data):
     data = (ctypes.c_byte * data_size)()
+    data_pointer = ctypes.cast(data, ctypes.POINTER(ctypes.c_void_p))
+
     status = _cdll.seekcamera_load_app_resources(
         camera.pointer,
         ctypes.c_int32(region),
-        ctypes.pointer(data),
+        data_pointer,
         ctypes.c_size_t(data_size),
         _memory_access_callback(callback),
         ctypes.py_object(user_data),
@@ -763,10 +765,14 @@ def cseekcamera_load_app_resources(camera, region, data_size, callback, user_dat
 def cseekcamera_store_app_resources(
     camera, region, data, data_size, callback, user_data
 ):
+    data_pointer = ctypes.cast(
+        (ctypes.c_byte * data_size).from_buffer(data), ctypes.POINTER(ctypes.c_void_p)
+    )
+
     return _cdll.seekcamera_store_app_resources(
         camera.pointer,
         ctypes.c_int32(region),
-        ctypes.pointer((ctypes.c_byte * data_size).from_buffer(data)),
+        data_pointer,
         ctypes.c_size_t(data_size),
         _memory_access_callback(callback),
         ctypes.py_object(user_data),

--- a/seekcamera/_clib.py
+++ b/seekcamera/_clib.py
@@ -270,6 +270,7 @@ def configure_dll():
         ctypes.c_void_p,
         ctypes.c_int32,
         ctypes.POINTER(ctypes.c_void_p),
+        ctypes.c_size_t,
         _SEEKCAMERA_MEMORY_ACCESS_CALLBACK_T,
         ctypes.py_object,
     ]


### PR DESCRIPTION
The function signatures for the C store/load app resources APIs
accept a `void*` for the `data` parameter. However, the Python language
bindings were passing an array of bytes without performing casting.
This resulted in a `TypeError` exception being raised.

Signed-off-by: Michael Mead <mmead.developer@gmail.com>